### PR TITLE
CI Update: Push on Main tests build, creates draft

### DIFF
--- a/.github/workflows/brave-build-and-draft.yaml
+++ b/.github/workflows/brave-build-and-draft.yaml
@@ -27,21 +27,6 @@ jobs:
         id: set-browser-version
         run: echo "BRAVE_VERSION=${{ steps.package.outputs.content }}" >> $GITHUB_ENV
       -
-        name: Create draft release on GitHub if doesn't exist
-        uses: ncipollo/release-action@v1
-        with:
-          draft: true
-          allowUpdates: true
-          tag: brave-${{ env.BRAVE_VERSION }}
-          body: "This release publishes the image: `webrecorder/browsertrix-browser-base:brave-${{ env.BRAVE_VERSION }}`\n\nThe image is hosted [on DockerHub](https://hub.docker.com/r/webrecorder/browsertrix-browser-base/tags?name=brave-${{ env.BRAVE_VERSION }})"
-      -
-        name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=webrecorder/browsertrix-browser-base
-          TAGS="${DOCKER_IMAGE}:brave-latest"
-          echo ::set-output name=tags::${TAGS}
-      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -
@@ -59,13 +44,22 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
+          push: false
           target: brave
           build-args: |
             BROWSER=brave
             BROWSER_VERSION=${{ env.BRAVE_VERSION }}
-          tags: ${{ steps.prep.outputs.tags }}
-          platforms: "linux/amd64"
+          tags: webrecorder/browsertrix-browser-base:brave-test
+          platforms: "linux/amd64,linux/arm64"
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+      -
+        name: Create draft release on GitHub if doesn't exist
+        uses: ncipollo/release-action@v1
+        with:
+          draft: true
+          allowUpdates: true
+          tag: brave-${{ env.BRAVE_VERSION }}
+          body: "This release publishes the image: `webrecorder/browsertrix-browser-base:brave-${{ env.BRAVE_VERSION }}`\n\nThe image is hosted [on DockerHub](https://hub.docker.com/r/webrecorder/browsertrix-browser-base/tags?name=brave-${{ env.BRAVE_VERSION }})"
+ 

--- a/.github/workflows/chrome-build-and-draft.yaml
+++ b/.github/workflows/chrome-build-and-draft.yaml
@@ -27,21 +27,6 @@ jobs:
         id: set-browser-version
         run: echo "CHROME_VERSION=${{ steps.package.outputs.content }}" >> $GITHUB_ENV
       -
-        name: Create draft release on GitHub if doesn't exist
-        uses: ncipollo/release-action@v1
-        with:
-          draft: true
-          allowUpdates: true
-          tag: chrome-${{ env.CHROME_VERSION }}
-          body: "This release publishes the image: `webrecorder/browsertrix-browser-base:chrome-${{ env.CHROME_VERSION }}`\n\nThe image is hosted [on DockerHub](https://hub.docker.com/r/webrecorder/browsertrix-browser-base/tags?name=chrome-${{ env.CHROME_VERSION }})"
-      -
-        name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=webrecorder/browsertrix-browser-base
-          TAGS=${DOCKER_IMAGE}:chrome-latest,${DOCKER_IMAGE}:latest
-          echo ::set-output name=tags::${TAGS}
-      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -
@@ -54,18 +39,27 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       -
-        name: Build and push
+        name: Testing Building
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
+          push: false
           target: chrome
           build-args: |
             BROWSER=chrome
             BROWSER_VERSION=${{ env.CHROME_VERSION }}
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: webrecorder/browsertrix-browser-base:chrome-test
           platforms: "linux/amd64,linux/arm64"
+      -
+        name: Create draft release on GitHub if doesn't exist
+        uses: ncipollo/release-action@v1
+        with:
+          draft: true
+          allowUpdates: true
+          tag: chrome-${{ env.CHROME_VERSION }}
+          body: "This release publishes the image: `webrecorder/browsertrix-browser-base:chrome-${{ env.CHROME_VERSION }}`\n\nThe image is hosted [on DockerHub](https://hub.docker.com/r/webrecorder/browsertrix-browser-base/tags?name=chrome-${{ env.CHROME_VERSION }})"
+ 
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Additional cleanup for the CI on push scripts to just test and create draft.
- Rename the -release.yaml files to -build-and-draft to avoid confusion with what they do.
- No publishing image on main push, just testing build
- Test building both arm/amd image with current version for chrome and brave (addresses #6)
- Draft created as last step, only if builds succeed.