### PR TITLE
Upgrade to Ubuntu Noble Numbat 24.04 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy AS base
+FROM ubuntu:noble AS base
 
 ARG BROWSER="brave"
 ENV BROWSER=$BROWSER
@@ -12,7 +12,7 @@ RUN apt-get update -y && apt-get install --no-install-recommends -qqy software-p
     && apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy build-essential locales-all redis-server apt-transport-https  \
       curl git socat jq xvfb x11vnc gosu gpg gpg-agent ca-certificates libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
-      libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2 libgtk-3-0 \
+      libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 libgtk-3-0 \
       libxtst6 xdg-utils libc-bin hicolor-icon-theme python3-pip python3-dev \
       fonts-arphic-ukai fonts-arphic-uming fonts-freefont-ttf fonts-gfs-neohellenic fonts-indic fonts-ipafont-mincho fonts-ipafont-gothic fonts-kacst \
       fonts-liberation fonts-noto-cjk fonts-noto-color-emoji fonts-roboto fonts-stix fonts-thai-tlwg fonts-ubuntu fonts-unfonts-core fonts-wqy-zenhei \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -y && apt-get install --no-install-recommends -qqy software-p
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy build-essential locales-all redis-server apt-transport-https  \
       curl git socat jq xvfb x11vnc gosu gpg gpg-agent ca-certificates libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
       libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 libgtk-3-0 \
-      libxtst6 xdg-utils libc-bin hicolor-icon-theme python3-pip python3-dev \
+      libxtst6 xdg-utils libc-bin hicolor-icon-theme python3-pip python3-dev python3-venv \
       fonts-arphic-ukai fonts-arphic-uming fonts-freefont-ttf fonts-gfs-neohellenic fonts-indic fonts-ipafont-mincho fonts-ipafont-gothic fonts-kacst \
       fonts-liberation fonts-noto-cjk fonts-noto-color-emoji fonts-roboto fonts-stix fonts-thai-tlwg fonts-ubuntu fonts-unfonts-core fonts-wqy-zenhei \
       msttcorefonts libu2f-udev libvulkan1 openssh-client sshpass


### PR DESCRIPTION
Fix #19 

Changes:
- changed base image
- moved from `libasound2` to `libasound2t64` since in `noble` it's a virtual package with two installation candidates, and `libasound2t64` seems to be the one closest to what was used in Jammy