### PR TITLE
security: harden Dockerfile package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG BROWSER="brave"
 ENV BROWSER=$BROWSER
 ARG BROWSER_VERSION="latest"
 ENV BROWSER_VERSION=$BROWSER_VERSION
+ARG TARGETARCH
 
 # Accept Microsoft EULA agreement for ttf-mscorefonts-installer
 RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections
@@ -18,13 +19,14 @@ RUN apt-get update -y && apt-get install --no-install-recommends -qqy software-p
       fonts-liberation fonts-noto-cjk fonts-noto-color-emoji fonts-roboto fonts-stix fonts-thai-tlwg fonts-sil-padauk fonts-ubuntu fonts-unfonts-core fonts-wqy-zenhei \
       msttcorefonts libu2f-udev libvulkan1 openssh-client sshpass autossh
 
-# Repo keys are stored as dedicated keyrings scoped via signed-by, rather than
-# apt-key (deprecated, trusts the key for every repo) or piping the NodeSource
-# setup script to bash (executes unverified remote code as root)
+# Yarn: https://classic.yarnpkg.com/en/docs/install#debian-stable
+# Node.js: replicates the repo setup from https://deb.nodesource.com/setup_24.x
+# (deb822 .sources + apt pin) without piping the setup script to bash
 RUN curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/yarnpkg-archive-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/yarnpkg-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/nodesource-keyring.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
+    && printf 'Types: deb\nURIs: https://deb.nodesource.com/node_24.x\nSuites: nodistro\nComponents: main\nArchitectures: %s\nSigned-By: /usr/share/keyrings/nodesource.gpg\n' "$TARGETARCH" > /etc/apt/sources.list.d/nodesource.sources \
+    && printf 'Package: nodejs\nPin: origin deb.nodesource.com\nPin-Priority: 600\n' > /etc/apt/preferences.d/nodejs \
     && apt-get update -y && apt-get install --no-install-recommends -qqy nodejs yarn \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,14 @@ RUN apt-get update -y && apt-get install --no-install-recommends -qqy software-p
       fonts-liberation fonts-noto-cjk fonts-noto-color-emoji fonts-roboto fonts-stix fonts-thai-tlwg fonts-sil-padauk fonts-ubuntu fonts-unfonts-core fonts-wqy-zenhei \
       msttcorefonts libu2f-udev libvulkan1 openssh-client sshpass autossh
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    && curl -sL https://deb.nodesource.com/setup_24.x -o /tmp/nodesource_setup.sh && bash /tmp/nodesource_setup.sh \
-    && apt-get update -y && apt-get install -qqy nodejs yarn \
+# Repo keys are stored as dedicated keyrings scoped via signed-by, rather than
+# apt-key (deprecated, trusts the key for every repo) or piping the NodeSource
+# setup script to bash (executes unverified remote code as root)
+RUN curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/yarnpkg-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnpkg-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/nodesource-keyring.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update -y && apt-get install --no-install-recommends -qqy nodejs yarn \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -34,35 +38,31 @@ ARG TARGETPLATFORM
 
 # Add Brave repository so we can grab brave-keyring after installing deb
 RUN curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main"|tee /etc/apt/sources.list.d/brave-browser-release.list \
-    && apt-get update
+    && echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main"|tee /etc/apt/sources.list.d/brave-browser-release.list
 
+# Select the brave-browser asset explicitly: releases also ship brave-origin
+# debs, so a bare "$TARGETARCH.deb" match picks up the wrong package
 RUN if [ "$BROWSER_VERSION" = "latest" ] ; \
     then \
-        debname=$(curl -sL "https://api.github.com/repos/brave/brave-browser/releases/latest" \
-            | grep "$TARGETARCH.deb\",$" \
-            | cut -d : -f 2,3 \
-            | tr -d \",\,,\[:space:]) \
-        && tagname=$(curl -sL "https://api.github.com/repos/brave/brave-browser/releases/latest" \
-            | grep "tag_name" \
-            | cut -d : -f 2,3 \
-            | tr -d \",\,,\[:space:]) \
-        && curl -sL "https://github.com/brave/brave-browser/releases/download/$tagname/$debname" -o brave.deb ; \
+        tagname=$(curl -fsSL "https://api.github.com/repos/brave/brave-browser/releases/latest" | jq -r '.tag_name') ; \
     else \
-        debname=$(curl -sL "https://api.github.com/repos/brave/brave-browser/releases/tags/v${BROWSER_VERSION}" \
-            | grep "$TARGETARCH.deb\",$" \
-            | cut -d : -f 2,3 \
-            | tr -d \",\,,\[:space:]) \
-        && curl -sL "https://github.com/brave/brave-browser/releases/download/v${BROWSER_VERSION}/$debname" -o brave.deb ; \
-    fi
+        tagname="v${BROWSER_VERSION}" ; \
+    fi \
+    && debname=$(curl -fsSL "https://api.github.com/repos/brave/brave-browser/releases/tags/${tagname}" \
+        | jq -r --arg arch "$TARGETARCH" '.assets[].name | select(test("^brave-browser_.*_" + $arch + "\\.deb$"))') \
+    && test -n "$debname" \
+    && curl -fsSL "https://github.com/brave/brave-browser/releases/download/${tagname}/${debname}" -o brave.deb
 
-RUN echo "installing Brave from $TARGETPLATFORM"; dpkg -i brave.deb; apt-get -f install -y; rm -f brave.deb
+# apt-get install (not dpkg -i; apt-get -f) so a corrupt or missing deb fails the build
+RUN echo "installing Brave from $TARGETPLATFORM" \
+    && apt-get update -y \
+    && apt-get install --no-install-recommends -qqy ./brave.deb \
+    && rm -f brave.deb \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN ln -s /usr/bin/brave-browser /usr/bin/chromium-browser
 
 RUN /usr/bin/brave-browser --version
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # -----------------------------------------------------------------------------
 
@@ -73,7 +73,7 @@ ARG TARGETPLATFORM
 
 COPY $BROWSER_VERSION/$TARGETPLATFORM/*.deb /tmp/deb/
 
-RUN echo "installing Chrome/Chromium from $TARGETPLATFORM"; dpkg -i /tmp/deb/*.deb; rm -rf /tmp/deb/
+RUN echo "installing Chrome/Chromium from $TARGETPLATFORM" && dpkg -i /tmp/deb/*.deb && rm -rf /tmp/deb/
 
 RUN if [ "$TARGETARCH" = "amd64" ] ; \
     then \


### PR DESCRIPTION
## Summary

Fixes three security issues in the Dockerfile found while scanning the image with Trivy and Hadolint:

1. **Deprecated `apt-key add` for the Yarn repo key** — `apt-key` trusts the key for *every* configured apt repo. Replaced with a dedicated keyring scoped to the Yarn repo via `signed-by`.
2. **NodeSource setup script piped to bash** — executed unverified remote code as root at build time. Replaced with the NodeSource GPG keyring + a pinned `deb [signed-by=...] https://deb.nodesource.com/node_24.x nodistro main` repo entry.
3. **Browser install failures silently swallowed** — `dpkg -i brave.deb; apt-get -f install -y` chains with `;`, so a corrupt deb "installs" successfully. This is currently breaking builds on `main`: Brave releases now also ship `brave-origin_*.deb` assets, so the `grep "$TARGETARCH.deb"` asset match hits two files, downloads garbage, and the failure only surfaces at the later `brave-browser --version` check. Fixed with explicit asset selection via `jq`, `curl -f`, and `apt-get install ./brave.deb` so a bad download fails the build immediately (same `;` → `&&` fix applied to the chrome target).

## Test plan

- [x] `./build.sh` (brave 1.91.171, arm64) builds successfully — it fails on `main` due to the brave-origin asset collision
- [x] Brave Browser 149.1.91.171 and Node v24.16.0 verified inside the built image
- [x] Trivy config scan: HIGH findings reduced from 4 to 1 (remaining `DS-0002` no-USER finding is intentional — this is a base image, downstream builds need root, and `gosu` is installed for runtime privilege dropping)
- [x] Hadolint: no errors, only pre-existing style warnings (version pinning, pipefail)