### PR TITLE
ci: pass GITHUB_TOKEN to github api requests to avoid 403s errors 

### DIFF
--- a/.github/workflows/brave-build-and-draft.yaml
+++ b/.github/workflows/brave-build-and-draft.yaml
@@ -41,7 +41,7 @@ jobs:
       -
         name: Test build
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false
@@ -50,6 +50,8 @@ jobs:
             BROWSER_NAME=brave-origin
             BROWSER_VERSION=${{ env.BRAVE_VERSION }}
           tags: webrecorder/browsertrix-browser-base:brave-test
+          secrets: |
+            "gh_token=${{ secrets.GITHUB_TOKEN }}"
           platforms: "linux/amd64,linux/arm64"
       -
         name: Image digest

--- a/.github/workflows/brave-update-check.yml
+++ b/.github/workflows/brave-update-check.yml
@@ -23,4 +23,6 @@ jobs:
       - name: Run update script
         run: ./update-brave.sh
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,7 +48,7 @@ jobs:
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
@@ -57,6 +57,8 @@ jobs:
             BROWSER=${{ env.BROWSER }}
             BROWSER_NAME=brave-origin
             BROWSER_VERSION=${{ env.BROWSER_VERSION }}
+          secrets: |
+            "gh_token=${{ secrets.GITHUB_TOKEN }}"
           tags: ${{ steps.prep.outputs.tags }}
           platforms: "linux/amd64,linux/arm64"
       -

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,16 +44,18 @@ RUN curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://br
 
 # Select the brave-browser asset explicitly: either brave-browser or brave-origin as set in BROWSER_NAME
 # debs, so a bare "$TARGETARCH.deb" match picks up the wrong package
-RUN if [ "$BROWSER_VERSION" = "latest" ] ; \
+RUN --mount=type=secret,id=gh_token \
+    GH_TOKEN=$(cat /run/secrets/gh_token); \
+    if [ "$BROWSER_VERSION" = "latest" ] ; \
     then \
-        tagname=$(curl -fsSL "https://api.github.com/repos/brave/brave-browser/releases/latest" | jq -r '.tag_name') ; \
+        tagname=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/brave/brave-browser/releases/latest" | jq -r '.tag_name') ; \
     else \
         tagname="v${BROWSER_VERSION}" ; \
     fi \
-    && debname=$(curl -fsSL "https://api.github.com/repos/brave/brave-browser/releases/tags/${tagname}" \
+    && debname=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/brave/brave-browser/releases/tags/${tagname}" \
         | jq -r --arg arch "$TARGETARCH" --arg browser "$BROWSER_NAME" '.assets[].name | select(test("^" + $browser + "_.*_" + $arch + "\\.deb$"))') \
     && test -n "$debname" \
-    && curl -fsSL "https://github.com/brave/brave-browser/releases/download/${tagname}/${debname}" -o brave.deb
+    && curl -fsSL -H "Authorization: Bearer $GH_TOKEN" "https://github.com/brave/brave-browser/releases/download/${tagname}/${debname}" -o brave.deb
 
 # apt-get install (not dpkg -i; apt-get -f) so a corrupt or missing deb fails the build
 RUN echo "installing Brave from $TARGETPLATFORM" \

--- a/update-brave.sh
+++ b/update-brave.sh
@@ -3,7 +3,7 @@ set -e
 
 current_version=$(cat brave-version.txt)
 latest_version=$(\
-    curl -s https://api.github.com/repos/brave/brave-browser/releases/latest \
+    curl -s -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/brave/brave-browser/releases/latest \
     | jq '.tag_name' \
     | sed -e 's/^"v//' -e 's/\"//')
 
@@ -26,7 +26,7 @@ if [ "$latest_version_when_sorted" != "$latest_version" ]; then
 fi
 
 release_http_status=$(\
-    curl -s -o /dev/null -w "%{http_code}" https://api.github.com/repos/brave/brave-browser/releases/tags/v${latest_version})
+    curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/brave/brave-browser/releases/tags/v${latest_version})
 
 if [ "$release_http_status" != "200" ]; then
     echo "Release not found, Github API returned $release_http_status"


### PR DESCRIPTION
for both building and checking version actions